### PR TITLE
feat: Implement per-zone persistence and i18n

### DIFF
--- a/src/main/java/net/mysterria/zones/MysterriaZones.java
+++ b/src/main/java/net/mysterria/zones/MysterriaZones.java
@@ -61,7 +61,7 @@ public class MysterriaZones extends JavaPlugin implements Listener {
         }
         
         if (zoneManager != null) {
-            zoneManager.saveZones();
+            zoneManager.getAllZones().forEach(zoneManager::saveZone);
         }
         
         saveConfigData();

--- a/src/main/java/net/mysterria/zones/commands/ZoneCommand.java
+++ b/src/main/java/net/mysterria/zones/commands/ZoneCommand.java
@@ -145,7 +145,7 @@ public class ZoneCommand implements TabExecutor {
 
         String zoneName = args[1];
         Zone zone = plugin.getZoneManager().getZone(zoneName);
-        
+
         if (zone == null) {
             player.sendMessage(Component.text("Zone '" + zoneName + "' not found!", NamedTextColor.RED));
             return;
@@ -158,50 +158,60 @@ public class ZoneCommand implements TabExecutor {
         player.sendMessage(Component.text("Max Point: " + zone.getMaxX() + ", " + zone.getMaxY() + ", " + zone.getMaxZ(), NamedTextColor.YELLOW));
         player.sendMessage(Component.text("Protection: " + (zone.isProtection() ? "Enabled" : "Disabled"), NamedTextColor.YELLOW));
         player.sendMessage(Component.text("Priority: " + zone.getPriority(), NamedTextColor.YELLOW));
-        player.sendMessage(Component.text("Enter Message: " + zone.getEnterMessage(), NamedTextColor.YELLOW));
-        player.sendMessage(Component.text("Exit Message: " + zone.getExitMessage(), NamedTextColor.YELLOW));
+
+        player.sendMessage(Component.text("Enter Messages:", NamedTextColor.YELLOW));
+        zone.getEnterMessages().forEach((lang, msg) ->
+                player.sendMessage(Component.text("  " + lang + ": " + msg, NamedTextColor.WHITE))
+        );
+
+        player.sendMessage(Component.text("Exit Messages:", NamedTextColor.YELLOW));
+        zone.getExitMessages().forEach((lang, msg) ->
+                player.sendMessage(Component.text("  " + lang + ": " + msg, NamedTextColor.WHITE))
+        );
     }
 
     private void handleSetEnter(Player player, String[] args) {
-        if (args.length < 3) {
-            player.sendMessage(Component.text("Usage: /zone setenter <name> <message>", NamedTextColor.RED));
+        if (args.length < 4) {
+            player.sendMessage(Component.text("Usage: /zone setenter <name> <lang> <message>", NamedTextColor.RED));
             return;
         }
 
         String zoneName = args[1];
         Zone zone = plugin.getZoneManager().getZone(zoneName);
-        
+
         if (zone == null) {
             player.sendMessage(Component.text("Zone '" + zoneName + "' not found!", NamedTextColor.RED));
             return;
         }
 
-        String message = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
-        zone.setEnterMessage(message);
-        plugin.getZoneManager().updateZone(zone);
-        
-        player.sendMessage(Component.text("Enter message updated for zone '" + zoneName + "'!", NamedTextColor.GREEN));
+        String lang = args[2].toLowerCase();
+        String message = String.join(" ", Arrays.copyOfRange(args, 3, args.length));
+        zone.getEnterMessages().put(lang, message);
+        plugin.getZoneManager().saveZone(zone);
+
+        player.sendMessage(Component.text("Enter message for language '" + lang + "' updated for zone '" + zoneName + "'!", NamedTextColor.GREEN));
     }
 
     private void handleSetExit(Player player, String[] args) {
-        if (args.length < 3) {
-            player.sendMessage(Component.text("Usage: /zone setexit <name> <message>", NamedTextColor.RED));
+        if (args.length < 4) {
+            player.sendMessage(Component.text("Usage: /zone setexit <name> <lang> <message>", NamedTextColor.RED));
             return;
         }
 
         String zoneName = args[1];
         Zone zone = plugin.getZoneManager().getZone(zoneName);
-        
+
         if (zone == null) {
             player.sendMessage(Component.text("Zone '" + zoneName + "' not found!", NamedTextColor.RED));
             return;
         }
 
-        String message = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
-        zone.setExitMessage(message);
-        plugin.getZoneManager().updateZone(zone);
-        
-        player.sendMessage(Component.text("Exit message updated for zone '" + zoneName + "'!", NamedTextColor.GREEN));
+        String lang = args[2].toLowerCase();
+        String message = String.join(" ", Arrays.copyOfRange(args, 3, args.length));
+        zone.getExitMessages().put(lang, message);
+        plugin.getZoneManager().saveZone(zone);
+
+        player.sendMessage(Component.text("Exit message for language '" + lang + "' updated for zone '" + zoneName + "'!", NamedTextColor.GREEN));
     }
 
     private void handleSetDisplay(Player player, String[] args) {

--- a/src/main/java/net/mysterria/zones/service/ZoneTrackingService.java
+++ b/src/main/java/net/mysterria/zones/service/ZoneTrackingService.java
@@ -52,12 +52,14 @@ public class ZoneTrackingService {
         Zone previousZone = playerCurrentZones.get(player.getUniqueId());
 
         if (currentZone != previousZone) {
+            String locale = player.getLocale().split("_")[0].toLowerCase();
+
             if (previousZone != null) {
-                onZoneExit(player, previousZone);
+                onZoneExit(player, previousZone, locale);
             }
-            
+
             if (currentZone != null) {
-                onZoneEnter(player, currentZone);
+                onZoneEnter(player, currentZone, locale);
                 playerCurrentZones.put(player.getUniqueId(), currentZone);
             } else {
                 playerCurrentZones.remove(player.getUniqueId());
@@ -65,10 +67,10 @@ public class ZoneTrackingService {
         }
     }
 
-    private void onZoneEnter(Player player, Zone zone) {
-        Component enterMessage = zone.getEnterComponent();
+    private void onZoneEnter(Player player, Zone zone, String locale) {
+        Component enterMessage = zone.getEnterComponent(locale);
         Component displayName = zone.getDisplayNameComponent();
-        
+
         player.showTitle(Title.title(
                 displayName,
                 enterMessage,
@@ -85,9 +87,9 @@ public class ZoneTrackingService {
         player.sendMessage(enterMessage);
     }
 
-    private void onZoneExit(Player player, Zone zone) {
-        Component exitMessage = zone.getExitComponent();
-        
+    private void onZoneExit(Player player, Zone zone, String locale) {
+        Component exitMessage = zone.getExitComponent(locale);
+
         player.showTitle(Title.title(
                 Component.text(""),
                 exitMessage,


### PR DESCRIPTION
This commit introduces two major features:

1.  **Per-Zone Persistence:**
    - Each zone is now saved in its own `.yml` file within a `zones/` directory.
    - This improves modularity and makes it easier to manage individual zone configurations.
    - The `ZoneManager` has been refactored to handle loading and saving zones from individual files.

2.  **Per-Zone Internationalization (i18n):**
    - Zone enter and exit messages can now be defined for multiple languages (e.g., 'en', 'uk').
    - The plugin detects the player's client language and sends the appropriate localized message.
    - If a translation is not available for a player's language, it defaults to English.
    - The `/zone setenter` and `/zone setexit` commands have been updated to support setting messages for specific languages.